### PR TITLE
Laravel 10 Mid-Shift

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -60,6 +60,7 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
+        'precognitive' => \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,

--- a/composer.json
+++ b/composer.json
@@ -10,25 +10,25 @@
     "type": "project",
     "require": {
         "php": "^8.1",
-        "coconutcraig/laravel-postmark": "^3.0",
+        "coconutcraig/laravel-postmark": "^3.1",
         "guzzlehttp/guzzle": "^7.2",
-        "laravel/framework": "^10.13",
-        "laravel/sanctum": "^3.2",
+        "laravel/framework": "^10.23",
+        "laravel/sanctum": "^3.3",
         "laravel/tinker": "^2.8",
         "mitydigital/sitemapamic": "^2.3",
-        "statamic/cms": "^4.0",
+        "statamic/cms": "^4.21",
         "statamic/podcast-categories": "^1.0",
         "symfony/http-client": "^6.2",
         "symfony/mailgun-mailer": "^6.2"
     },
     "require-dev": {
-        "barryvdh/laravel-debugbar": "^3.8",
+        "barryvdh/laravel-debugbar": "^3.9",
         "fakerphp/faker": "^1.9.1",
-        "laravel/sail": "^1.18",
+        "laravel/sail": "^1.25",
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^7.0",
-        "phpunit/phpunit": "^9.5.10",
-        "spatie/laravel-ignition": "^2.0"
+        "phpunit/phpunit": "^10.0",
+        "spatie/laravel-ignition": "^2.3"
     },
     "config": {
         "optimize-autoloader": true,

--- a/config/queue.php
+++ b/config/queue.php
@@ -75,6 +75,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Job Batching
+    |--------------------------------------------------------------------------
+    |
+    | The following options configure the database and table that store job
+    | batching information. These options can be updated to any database
+    | connection and table which has been defined by your application.
+    |
+    */
+
+    'batching' => [
+        'database' => env('DB_CONNECTION', 'mysql'),
+        'table' => 'job_batches',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Failed Queue Jobs
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
This pull request includes recent changes to Laravel skeleton files. Although some of these changes may be considered optional, they may be required to use recent additions - such as the [`hashed` attribute cast](https://github.com/laravel/framework/pull/46947) and [log processors](https://github.com/laravel/framework/pull/46344). This also includes new configuration options and skeleton slimming.

Since Laravel has moved to an annual release cycle, changes since the initial release may reach a critical mass. When they do, you will receive this automated pull request as part of your _Shifty Plan_.

**Before merging**, you need to:

- Checkout the `shift-mid-laravel-10` branch
- Review **all** pull request comments for additional changes
- Run `composer update` (if the scripts fail, add `--no-scripts`)
- Clear any config, route, or view cache
- Thoroughly test your application ([no tests?](https://laravelshift.com/laravel-test-generator), [no CI?](https://laravelshift.com/ci-generator))

If you would like more detail you may [view the full changes](https://github.com/laravel/laravel/compare/v10.0.0...v10.2.6). You may also stay informed of weekly Laravel release highlights through the [Shifty Bits Newsletter](https://shiftybits.news/).
